### PR TITLE
Raise proper errors when Bad Things(tm) happen

### DIFF
--- a/lib/UbersmithClient.js
+++ b/lib/UbersmithClient.js
@@ -2,6 +2,8 @@
 
 const request = require('request');
 const urlencode = require('urlencode');
+const UbersmithError = require('./errors/UbersmithError');
+
 
 class UbersmithClient {
     constructor(uri, user, password, timeout=60, use_http_get=false) {
@@ -56,10 +58,27 @@ class UbersmithClient {
                 if (error) {
                     reject(error);
                 } else {
-                    if (body.status) {
-                        resolve(body.data);
+                    if (response.statusCode == 200) { // Valid Ubersmith response
+                        // Responses are returned in JSON format (with the exception of specialized methods which return raw PDF, Image, XML or HTML data), and include the standard elements:
+                        //     status - API call success true/false
+                        //     error_code - error code for failed API calls
+                        //     error_message - error message for failed API calls
+                        //     data - results of API call
+                        //
+                        // Example Output
+                        // {
+                        //     "status":true,
+                        //     "error_code":null,
+                        //     "error_message":"",
+                        //     "data": "<api call output here>"
+                        // }
+                        if (body.status) {
+                            resolve(body.data);
+                        } else {
+                            reject(new UbersmithError.ubersmithApplicationError(body));
+                        }
                     } else {
-                        reject(body.error_message);
+                        reject(new UbersmithError.ubersmithTransportError(response.body, response.statusCode));
                     }
                 }
             });

--- a/lib/errors/UbersmithError.js
+++ b/lib/errors/UbersmithError.js
@@ -1,0 +1,33 @@
+'use strict';
+
+class UbersmithError extends Error {
+    constructor(message, code) {
+        super(message);
+
+        this.name = this.constructor.name;
+        this.code = code;
+
+        Error.captureStackTrace && Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+class UbersmithApplicationError extends UbersmithError {
+    constructor(error) {
+        super(error.error_message || 'API call failure');
+        this.error = error;
+    }
+}
+
+class UbersmithTransportError extends UbersmithError {
+    constructor(message, code) {
+        super(message || 'An unknown error occurred');
+        this.code = code;
+    }
+}
+
+module.exports = {
+    ubersmithError: UbersmithError,
+    ubersmithTransportError: UbersmithTransportError,
+    ubersmithApplicationError: UbersmithApplicationError,
+};
+

--- a/test/UbersmithClient.spec.js
+++ b/test/UbersmithClient.spec.js
@@ -2,6 +2,7 @@
 
 const UbersmithClient = require('../index');
 const responses = require('./responses/client.list');
+const UbersmithError = require('../lib/errors/UbersmithError');
 
 const nock = require('nock');
 const chai = require('chai');
@@ -16,7 +17,7 @@ const config = {
 
 describe('Ubersmith Client', () => {
 
-    describe('Get clients', () => {
+    describe('In GET mode', () => {
 
         beforeEach(() => {
             this.client = new UbersmithClient(config.url,
@@ -54,18 +55,60 @@ describe('Ubersmith Client', () => {
                 })
         });
 
-        function _mockHttpGet(baseUrl, endpoint, statusCode, responsePayload) {
+        it('should raise a UbersmithTransportError when response has HTTP code below 200', done => {
+            _mockHttpGet(config.url, '/api/2.0/?method=uber.method_name', 199,
+                'EXACT ERROR TEXT', {'Content-Type': 'text/html'});
+
+            this.client.uber.method_name()
+                .then(res => {
+                    done('should not get here');
+                })
+                .catch(err => {
+                    expect(err).to.deep.equal(new UbersmithError.ubersmithTransportError('EXACT ERROR TEXT', 199));
+                    done();
+                })
+        });
+
+        it('should raise a UbersmithTransportError when response has HTTP code 450', done => {
+            _mockHttpGet(config.url, '/api/2.0/?method=uber.method_name', 450,
+                'EXACT ERROR TEXT', {'Content-Type': 'text/html'});
+
+            this.client.uber.method_name()
+                .then(res => {
+                    done('should not get here');
+                })
+                .catch(err => {
+                    expect(err).to.deep.equal(new UbersmithError.ubersmithTransportError('EXACT ERROR TEXT', 450));
+                    done();
+                })
+        });
+
+        it('should raise a UbersmithApplicationError when API call was not a success', done => {
+            _mockHttpGet(config.url, '/api/2.0/?method=client.list', 200, responses.errored);
+
+            this.client.client.list()
+                .then(res => {
+                    done('should not get here');
+                })
+                .catch(err => {
+                    expect(err).to.deep.equal(new UbersmithError.ubersmithApplicationError(responses.errored));
+                    done();
+                });
+
+        });
+
+        function _mockHttpGet(baseUrl, endpoint, statusCode, responsePayload, headers={}) {
             nock(baseUrl)
                 .get(endpoint)
                 .basicAuth({
                     user: config.user,
                     pass: config.password
                 })
-                .reply(statusCode, responsePayload);
+                .reply(statusCode, responsePayload, headers);
         }
     });
 
-    describe('POST clients', () => {
+    describe('In POST mode', () => {
 
         beforeEach(() => {
             this.client = new UbersmithClient(config.url,
@@ -118,14 +161,71 @@ describe('Ubersmith Client', () => {
                 })
         });
 
-        function _mockHttpPost(baseUrl, endpoint, data, statusCode, responsePayload) {
+        it('should raise a UbersmithTransportError when response has HTTP code below 200', done => {
+            _mockHttpPost(config.url,
+                '/api/2.0/',
+                {
+                    method: 'uber.method_name'
+                },
+                199,
+                'EXACT ERROR TEXT', {'Content-Type': 'text/html'});
+
+            this.client.uber.method_name()
+                .then(res => {
+                    done('should not get here');
+                })
+                .catch(err => {
+                    expect(err).to.deep.equal(new UbersmithError.ubersmithTransportError('EXACT ERROR TEXT', 199));
+                    done();
+                })
+        });
+
+        it('should raise a UbersmithTransportError when response has HTTP code 450', done => {
+            _mockHttpPost(config.url,
+                '/api/2.0/',
+                {
+                    method: 'uber.method_name'
+                },
+                450,
+                'EXACT ERROR TEXT', {'Content-Type': 'text/html'});
+
+            this.client.uber.method_name()
+                .then(res => {
+                    done('should not get here');
+                })
+                .catch(err => {
+                    expect(err).to.deep.equal(new UbersmithError.ubersmithTransportError('EXACT ERROR TEXT', 450));
+                    done();
+                })
+        });
+
+        it('should raise a UbersmithApplicationError when API call was not a success', done => {
+            _mockHttpPost(config.url,
+                '/api/2.0/',
+                {
+                    method: 'client.list'
+                },
+                200, responses.errored);
+
+            this.client.client.list()
+                .then(res => {
+                    done('should not get here');
+                })
+                .catch(err => {
+                    expect(err).to.deep.equal(new UbersmithError.ubersmithApplicationError(responses.errored));
+                    done();
+                });
+
+        });
+
+        function _mockHttpPost(baseUrl, endpoint, data, statusCode, responsePayload, headers={}) {
             nock(baseUrl)
                 .post(endpoint, data)
                 .basicAuth({
                     user: config.user,
                     pass: config.password
                 })
-                .reply(statusCode, responsePayload);
+                .reply(statusCode, responsePayload, headers);
         }
     });
 

--- a/test/responses/client.list.js
+++ b/test/responses/client.list.js
@@ -1,5 +1,17 @@
+const errored = {
+    "status": false,
+    "error_code": 42,
+    "error_message": "Failed to do something",
+    "data":{
+        "Something bad happened": "the other day",
+    }
+};
+
 const all = {
-    "status":true,"error_code":null,"error_message":"","data":{
+    "status": true,
+    "error_code": null,
+    "error_message": "",
+    "data": {
         "12345":{"clientid":"12345","first":"","last":"","checkname":""},
         "12346":{"clientid":"12346","first":"","last":"","checkname":""},
         "12347":{"clientid":"12347","first":"","last":"","checkname":""},
@@ -9,12 +21,16 @@ const all = {
 };
 
 const filtered = {
-    "status":true,"error_code":null,"error_message":"","data":{
+    "status": true,
+    "error_code": null,
+    "error_message": "",
+    "data": {
         "12345":{"clientid":"12345","first":"","last":"","checkname":""}
     }
 };
 
 module.exports = {
     all: all,
-    filtered: filtered
+    filtered: filtered,
+    errored: errored
 };


### PR DESCRIPTION
Currently, the library will not provide the ability to distinguish
between a transport failure and an actual API call failure. This limits
attempts at doing The Right Thing(tm) in software using this library.

This commit ensures the following cases are handled:

Transport errors:
  * Generic transport errors (connection timed out, unreachable, etc.)
  * Non HTTP 200 cases (those are typical in custom non-vanilla modules)

Application errors:
  * Actual RPC call failure, indicated by status: false in response
  * Generic non-Ubersmith response, encapsulated in a 200 response
  * Non-application/json responses